### PR TITLE
add option to use source (friendly to loader chains)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ module: {
 ```js
 var resolvedSchema = require('./schema.json');
 ```
+
+### Options
+
+#### `useSource: boolean`
+
+This loader normally passes the RefParser the `resourcePath`, not the source.  If you want to chain loaders, make sure to set `useSource=true`.

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,12 +1,15 @@
+var loaderUtils = require('loader-utils');
 var _ = require('lodash');
 var RefParser = require('json-schema-ref-parser');
 
 module.exports = function(source) {
+  var query = loaderUtils.parseQuery(this.query);
+
   var callback = this.async();
   var parser = new RefParser();
   this.cacheable && this.cacheable();
 
-  parser.dereference(this.resourcePath)
+  parser.dereference(query.useSource ? JSON.parse(source) : this.resourcePath)
     .then(handleResolveSuccess.bind(this))
     .catch(callback);
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "type": "git"
   },
   "dependencies": {
-    "lodash": "^4.10.0",
-    "json-schema-ref-parser": "^3.0.2"
+    "json-schema-ref-parser": "^3.0.2",
+    "loader-utils": "^0.2.16",
+    "lodash": "^4.10.0"
   }
 }


### PR DESCRIPTION
I could not use this loader with the following config:

```js
{
  test: /\.schema\.json$/,
  loaders: ['json-schema-loader', 'webpack-comment-remover-loader']
}
```

Now I can with this:

```js
{
  test: /\.schema\.json$/,
  loaders: ['json-schema-loader?useSource=true', 'webpack-comment-remover-loader']
}
```