### PR TITLE
Support circular references and reduce file size

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -9,7 +9,7 @@ module.exports = function(source) {
   var parser = new RefParser();
   this.cacheable && this.cacheable();
 
-  parser.dereference(query.useSource ? JSON.parse(source) : this.resourcePath)
+  parser.bundle(query.useSource ? JSON.parse(source) : this.resourcePath)
     .then(handleResolveSuccess.bind(this))
     .catch(callback);
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -17,6 +17,6 @@ module.exports = function(source) {
     this.value = [schema];
     var json = JSON.stringify(schema, null, 2);
     _.map(parser.$refs.paths(), this.addDependency);
-    callback(null, 'module.exports = ' + json + ';', schema);
+    callback(null, json, schema);
   }
 }


### PR DESCRIPTION
Currently, this library uses `json-schema-ref-parser`'s `dereference` method. This method will create a JSON object where all references are resolved into the schemas themselves.

There are two issues with this approach:

* Doesn't support circular references
* May result in unnecessarily inflated file sizes

### Circular references

When trying to load a schema that returns recursive/circular references, json-schema-loader will barf:

```
    ERROR in ./src/schemas/MySchema.json
    Module build failed: TypeError: Converting circular structure to JSON
        at Object.stringify (native)
        at Object.handleResolveSuccess (.../node_modules/json-schema-loader/lib/loader.js:18:21)
     @ ./~/babel-loader/lib!./src/code/workers/validate.worker.js 11:14-50
```

This is because in `dereference` mode json-schema-ref-parser's return value contains circular references which can't be serialized to JSON.

### Unnecessarily inflated file size

Some schemas may contain the same reference multiple times. In this case, `dereference` mode will create references to the same JSON object in memory, which is fine. However, when serializing the resulting structure, it will copy the entire subobject, triggering potentially very large trees of objects to be copied over and over.

### Solution

Aside from `dereference`, `json-schema-ref-parser` also offers another mode: `bundle`

In `bundle` mode, it will create a single, serializable JSON schema and use JSON schema references (`$ref`) to link the different parts of the schema together.

This seems to be a much better fit for json-schema-loader, because it solves the issues mentioned above.